### PR TITLE
export run-package-tests in test packages

### DIFF
--- a/source/suite.lisp
+++ b/source/suite.lisp
@@ -97,6 +97,7 @@ PACKAGE-OPTIONS, automatically USEs the :FIASCO and :CL packages."
        (defpackage ,name
          ,@(append `((:use :fiasco :cl))
                    package-options))
+       (export 'run-package-tests ,name)
        (defsuite (,suite-sym :ignore-home-package t
                              :bind-to-package ,name
                              :in fiasco-suites::all-tests)))))


### PR DESCRIPTION
I was also thinking that fiasco-fixtures should export all-tests and the per test-package defined function. Would you be inclined to such PR?
