### PR TITLE
Avoid calling (eval *test-run-standard-output*)

### DIFF
--- a/src/infrastructure.lisp
+++ b/src/infrastructure.lisp
@@ -27,8 +27,8 @@
 (defvar *warn-about-test-redefinitions* nil)
 
 ;; TODO introduce *progress-output*
-(defvar *test-run-standard-output* '*standard-output*
-  "*STANDARD-OUTPUT* is bound to (eval *test-run-standard-output*) at
+(defvar *test-run-standard-output* (make-synonym-stream '*standard-output*)
+  "*STANDARD-OUTPUT* is bound to *TEST-RUN-STANDARD-OUTPUT* at
 the toplevel entry point to any test.")
 
 (defvar *tests* (make-hash-table :test 'eql)) ; this is not thread-safe, but...

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -25,6 +25,7 @@
            #:run-failed-tests
            #:extract-test-run-statistics
 
+           #:*test-run-standard-output*
            #:*test-progress-print-right-margin*
            #:*test-result-history*
            #:*last-test-result*

--- a/src/test.lisp
+++ b/src/test.lisp
@@ -117,7 +117,7 @@ returning (values)~@:>" (name-of test)))
                  (if parent-context
                      (,body-sym)
                      (with-toplevel-restarts
-                       (let ((*standard-output* (eval *test-run-standard-output*))
+                       (let ((*standard-output* *test-run-standard-output*)
                              (*debug-on-assertion-failure* *debug-on-assertion-failure*)
                              (*debug-on-unexpected-error*  *debug-on-unexpected-error*)
                              (*print-test-run-progress*    *print-test-run-progress*)


### PR DESCRIPTION
Instead of binding `*TEST-RUN-STANDARD-OUTPUT*` to a symbol to be
evaluated, use make-synonym-stream to bind it to an alias
of `*STANDARD-OUTPUT*` to achieve the same functionality.

Hat tip to [http://lisptips.com/post/127524780849/when-a-synonym-stream-is-useful](lisp tips)
