### PR TITLE
Make `fiasco:all-tests' use `run-package-tests' for nice output

### DIFF
--- a/src/package.lisp
+++ b/src/package.lisp
@@ -38,6 +38,7 @@
            #:*warn-about-test-redefinitions*
            #:all-tests
            #:define-test-package
+	   #:run-tests
            #:run-package-tests
            #:describe-failed-tests
            #:run-suite-tests))

--- a/src/suite.lisp
+++ b/src/suite.lisp
@@ -94,7 +94,8 @@ Returns two values:
 2. A list of objects containing test results for each executed suite.
 
 PACKAGE defaults to the current package. Don't supply both both
-PACKAGE and PACKAGES.
+PACKAGE and PACKAGES. It's possible to supply objects of type TEST
+rather than packages here, if needed.
 
 With optional INTERACTIVE, run tests interactively, i.e. break on
 errors and unexpected assertion failures. 

--- a/src/suite.lisp
+++ b/src/suite.lisp
@@ -55,7 +55,7 @@ Namespace for Fiasco suites defined via DEFINE-TEST-PACKAGE."))
 
 (defun all-tests ()
   "Run all currently defined tests."
-  (fiasco-suites::all-tests))
+  (run-package-tests :package (find-test 'fiasco-suites::all-tests)))
 
 (defmacro define-test-package (name &body package-options)
   "Defines package NAME and binds to it a new suite test suite.
@@ -110,7 +110,9 @@ its docstring."
   (loop for package in (alexandria:ensure-list (if packages-supplied-p
                                                    packages
                                                    package))
-        for suite = (find-suite-for-package (find-package package))
+        for suite = (if (eql (type-of package) 'test)
+		        package
+			(find-suite-for-package (find-package package)))
         for result = (progn
                        (assert suite nil "Can't find a test suite for package ~a" package)
                        (run-suite-tests suite

--- a/src/suite.lisp
+++ b/src/suite.lisp
@@ -110,9 +110,9 @@ its docstring."
   (loop for package in (alexandria:ensure-list (if packages-supplied-p
                                                    packages
                                                    package))
-        for suite = (if (eql (type-of package) 'test)
-		        package
-			(find-suite-for-package (find-package package)))
+        for suite = (typecase package
+		      (test package)
+		      (otherwise (find-suite-for-package (find-package package))))
         for result = (progn
                        (assert suite nil "Can't find a test suite for package ~a" package)
                        (run-suite-tests suite


### PR DESCRIPTION
This should give users the ability to easily run all defined test packages using `fiasco:all-tests` and still get the nice, verbose output of `run-package-tests`.

The solution is perhaps a bit hack-ish, but these are the simplest changes I could think of. `run-package-tests` is modified so that it can accept a `test` type instead of a package, and then it's used to run `fiasco-suites::all-tests`, which is the parent suite of all defined packages.

@luismbo What do you think?

