### PR TITLE
Make IS not emit unreachable clauses

### DIFF
--- a/src/asserts.lisp
+++ b/src/asserts.lisp
@@ -137,13 +137,13 @@
          (let* (,@bindings
                 (,result (multiple-value-list ,expression)))
            (multiple-value-bind (,format-control ,format-arguments)
-               (if (and ,message-p *always-show-failed-sexp*)
-                   (values (format nil "~A~%~%~A" ,message ,expression-message)
-                           (list ,@message-args ,@expression-message-args))
-                   ,(if message-p
-                        `(values ,message (list ,@message-args))
-                        `(values ,expression-message
-                                 (list ,@expression-message-args))))
+               ,(if message-p
+		    `(if *always-show-failed-sexp*
+			 (values (format nil "~A~%~%~A" ,message ,expression-message)
+				 (list ,@message-args ,@expression-message-args))
+			 (values ,message (list ,@message-args)))
+		    `(values ,expression-message
+			     (list ,@expression-message-args)))
 
              (if (first ,result)
                  (register-assertion-was-successful)


### PR DESCRIPTION
E.g., ACL 10.1 yields the following warning for `(is t)`:
Warning: cond clause (T *ALWAYS-SHOW-FAILED-SEXP*) is unreachable