### PR TITLE
more useful test output reporting

### DIFF
--- a/src/infrastructure.lisp
+++ b/src/infrastructure.lisp
@@ -17,7 +17,9 @@
 (defvar *root-suite*)
 (defvar *package-bound-suites* (make-hash-table))
 (defvar *print-test-run-progress* t)
-(defvar *test-progress-print-right-margin* 80)
+;;; 79 and not 80 to account for a line overflow \ in some editors and
+;;; terminals
+(defvar *test-progress-print-right-margin* 79)
 (defvar *debug-on-unexpected-error* t)
 (defvar *debug-on-assertion-failure* t)
 (defvar *test-result-history* '())


### PR DESCRIPTION
This PR significantly changes what the output looks like for running tests. It is noisier, but a lot more useful during actual Lisp development, or even when reading logs from a CI server.

At Rigetti Computing, it has been very frequently annoying to have to look at the backtrace to see what test has failed during an interactive session. It is also extremely confusing to notice which test is printing intermediate output.

This change changes from the old look:

```
PROJECT-TESTS (Suite)
  TEST-QUEUE                                                             [ OK ]
  TEST-QUEUE-MAKE                                                        [ OK ]
  TEST-NSPLIT                                                            [ OK ]
  TEST-LEXER                                                             [ OK ]
    Testing good file bell
    Testing good file empty
  TEST-PARSING-GOOD-TEST-FILES                                           [ OK ]
```
Note that the intermediate output comes from `TEST-PARSING-GOOD...`!

The new, unconfusing look is:

```
CL-QUIL-TESTS (Suite)
  Starting TEST-QUEUE
  Finished TEST-QUEUE  . . . . . . . . . . . . . . . . . . . . . . . . . [ OK ]
  Starting TEST-QUEUE-MAKE
  Finished TEST-QUEUE-MAKE . . . . . . . . . . . . . . . . . . . . . . . [ OK ]
  Starting TEST-NSPLIT
  Finished TEST-NSPLIT . . . . . . . . . . . . . . . . . . . . . . . . . [ OK ]
  Starting TEST-LEXER
  Finished TEST-LEXER  . . . . . . . . . . . . . . . . . . . . . . . . . [ OK ]
  Starting TEST-PARSING-GOOD-TEST-FILES
    Testing good file bell
    Testing good file empty
  Finished TEST-PARSING-GOOD-TEST-FILES  . . . . . . . . . . . . . . . . [ OK ]
```