### PR TITLE
Correctly skip tests in Allegro Common Lisp

### DIFF
--- a/src/asserts.lisp
+++ b/src/asserts.lisp
@@ -218,7 +218,7 @@ there a superfulous quote at ~S?)" condition-type))
                            :format-arguments ,whole))))))
 
 (defun skip ()
-  (warn 'test-skipped))
+  (signal 'test-skipped))
 
 (defmacro skip-unless (condition)
   `(unless ,condition (skip)))

--- a/src/infrastructure.lisp
+++ b/src/infrastructure.lisp
@@ -294,7 +294,7 @@ missing (in-root-suite)?"
                           while context collect context))
             (error-of self))))
 
-(define-condition test-skipped (warning)
+(define-condition test-skipped ()
   ()
   (:documentation "Signalled when test is skipped"))
 
@@ -422,7 +422,7 @@ and has no parent")
             (lambda ()
               (setf *debug-on-unexpected-error* nil
                     *debug-on-assertion-failure* nil)
-              (continue))
+              (invoke-restart 'skip-test))
             :report-function (lambda (stream)
                                (format stream "~
 ~@<Turn off debugging for this test session and invoke the first ~
@@ -430,7 +430,7 @@ CONTINUE restart~@:>")))
           (continue-without-debugging-errors
             (lambda ()
               (setf *debug-on-unexpected-error* nil)
-              (continue))
+              (invoke-restart 'skip-test))
             :report-function (lambda (stream)
                                (format stream "~
 ~@<Do not stop at unexpected errors for the rest of this test session ~
@@ -438,7 +438,7 @@ and continue by invoking the first CONTINUE restart~@:>")))
           (continue-without-debugging-assertions
             (lambda ()
               (setf *debug-on-assertion-failure* nil)
-              (continue))
+              (invoke-restart 'skip-test))
             :report-function (lambda (stream)
                                (format stream "~
 ~@<Do not stop at failed assertions for the rest of this test session ~


### PR DESCRIPTION
The execution registers the internal run time, but I believe it should register the real time.

Additionally, the skip functionality is broken in ACL.
Probably due to differences in behaviour for the continue restart that warnings automatically provide.
By providing and using an explicit restart, we can avoid the problem.