### PR TITLE
Fix define-test-package for abcl

### DIFF
--- a/src/suite.lisp
+++ b/src/suite.lisp
@@ -76,8 +76,6 @@ processing PACKAGE-OPTIONS, automatically USES the :FIASCO and :CL
 packages."
   (destructuring-bind (name &key (in 'fiasco-suites::all-tests))
       (alexandria:ensure-list name-or-name-with-args)
-    (unless (find-package name)
-      (make-package name :use nil))
     (let ((suite-sym (intern (string name) :fiasco-suites)))
       `(progn
 	 (defpackage ,name

--- a/test/basic.lisp
+++ b/test/basic.lisp
@@ -23,13 +23,20 @@
 
                 #:*context*
 
+                #:find-suite-for-package
+
                 #:lambda-list-to-value-list-expression
                 #:lambda-list-to-funcall-expression
                 #:lambda-list-to-variable-name-list))
 (in-package #:fiasco-basic-self-tests)
 
 (deftest fiasco-define-test-package ()
-  (is (not (null (package-use-list *package*)))))
+  (is (not (null (package-use-list *package*))))
+  (multiple-value-bind (suite foundp)
+      (find-suite-for-package *package*)
+    (is (not (null foundp)))
+    (is (eq 'fiasco-suites::fiasco-basic-self-tests
+            (name-of suite)))))
 
 (deftest lifecycle ()
   (let* ((original-test-count (count-tests *suite*))

--- a/test/basic.lisp
+++ b/test/basic.lisp
@@ -28,6 +28,9 @@
                 #:lambda-list-to-variable-name-list))
 (in-package #:fiasco-basic-self-tests)
 
+(deftest fiasco-define-test-package ()
+  (is (not (null (package-use-list ':fiasco-basic-self-tests)))))
+
 (deftest lifecycle ()
   (let* ((original-test-count (count-tests *suite*))
          (suite-name (gensym "TEMP-SUITE"))

--- a/test/basic.lisp
+++ b/test/basic.lisp
@@ -29,7 +29,7 @@
 (in-package #:fiasco-basic-self-tests)
 
 (deftest fiasco-define-test-package ()
-  (is (not (null (package-use-list ':fiasco-basic-self-tests)))))
+  (is (not (null (package-use-list *package*)))))
 
 (deftest lifecycle ()
   (let* ((original-test-count (count-tests *suite*))


### PR DESCRIPTION
Copy/paste commit message:

Remove MAKE-PACKAGE call from DEFINE-TEST-PACKAGE

This was causing failures on ABCL. Previously, DEFINE-TEST-PACKAGE
would define the package twice, once by calling MAKE-PACKAGE during
the macro expansion, and once by including a DEFPACKAGE in the form
returned by the macro expansion. The call to MAKE-PACKAGE at macro
expansion time specified :USE NIL whereas the DEFPACKAGE would include
any :USE clauses specified by the caller, plus an additional '(:USE
:CL :FIASCO).

From the hyperspec entry for DEFPACKAGE

> If defined-package-name already refers to an existing package, the
> name-to-package mapping for that name is not changed. If the new
> definition is at variance with the current state of that package,
> the consequences are undefined; an implementation might choose to
> modify the existing package to reflect the new definition. If
> defined-package-name is a symbol, its name is used.

Although many implementations take the suggested approach of updating
the package to reflect the new definition, ABCL seemingly does not and
thus the PACKAGE-USE-LIST of the resulting package would remain empty.